### PR TITLE
design : basic editor UI 구현 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "recoil": "^0.7.5",
         "styled-components": "^5.3.5",
         "styled-reset": "^4.4.2",
+        "survey-react-ui": "^1.9.50",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -14958,6 +14959,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/survey-core": {
+      "version": "1.9.50",
+      "resolved": "https://registry.npmjs.org/survey-core/-/survey-core-1.9.50.tgz",
+      "integrity": "sha512-n1vJi+x/IJSGgUt/n40sTO/2h5M3PK5sHLKUY7gn6nEF531r/OFG6euO/X/kBK2HTCMYH85sr/Rqp3QCdg2ksg=="
+    },
+    "node_modules/survey-react-ui": {
+      "version": "1.9.50",
+      "resolved": "https://registry.npmjs.org/survey-react-ui/-/survey-react-ui-1.9.50.tgz",
+      "integrity": "sha512-if9/N+1H1UuHV7av03sdBiPjvB5qz9uuSI7a50tOyD8cSXupMt/I+nbDIlPV+9MA/2SH9QIPPR9Nx1g30cEiMg==",
+      "dependencies": {
+        "react": "^16.5.0 || ^17.0.1 || ^18.1.0",
+        "react-dom": "^16.5.0 || ^17.0.1 || ^18.1.0",
+        "survey-core": "*"
+      }
+    },
     "node_modules/svg-parser": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
@@ -27335,6 +27351,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
+    "survey-core": {
+      "version": "1.9.50",
+      "resolved": "https://registry.npmjs.org/survey-core/-/survey-core-1.9.50.tgz",
+      "integrity": "sha512-n1vJi+x/IJSGgUt/n40sTO/2h5M3PK5sHLKUY7gn6nEF531r/OFG6euO/X/kBK2HTCMYH85sr/Rqp3QCdg2ksg=="
+    },
+    "survey-react-ui": {
+      "version": "1.9.50",
+      "resolved": "https://registry.npmjs.org/survey-react-ui/-/survey-react-ui-1.9.50.tgz",
+      "integrity": "sha512-if9/N+1H1UuHV7av03sdBiPjvB5qz9uuSI7a50tOyD8cSXupMt/I+nbDIlPV+9MA/2SH9QIPPR9Nx1g30cEiMg==",
+      "requires": {
+        "react": "^16.5.0 || ^17.0.1 || ^18.1.0",
+        "react-dom": "^16.5.0 || ^17.0.1 || ^18.1.0",
+        "survey-core": "*"
+      }
     },
     "svg-parser": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "recoil": "^0.7.5",
     "styled-components": "^5.3.5",
     "styled-reset": "^4.4.2",
+    "survey-react-ui": "^1.9.50",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Nav from './components/nav/Nav';
+import Editor from './pages/editor/Editor';
 import Main from './pages/main/Main';
 import Login from './pages/Login/Login';
 
@@ -10,6 +11,7 @@ const Router = () => {
       <Routes>
         <Route path="/" element={<Main />} />
         <Route path="/admin/login" element={<Login />} />
+        <Route path="/editor:id" element={<Editor />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/GlobalButton.js
+++ b/src/components/GlobalButton.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const GlobalButton = ({ title }) => {
+  return <Container>{title}</Container>;
+};
+
+export default GlobalButton;
+
+const Container = styled.button`
+  margin-left: ${title => title.children === '...' || '10px'};
+  padding: ${title =>
+    title.children === '이전으로 가기' || '다음으로 가기' ? '5Px 10px' : 0};
+  color: #ffffff;
+  border-color: ${props => props.theme.style.mainBlue};
+  background-color: ${props => props.theme.style.mainBlue};
+  border-radius: 25px;
+  width: ${title =>
+    title.children === '이전으로 가기' || '다음으로 가기' ? 'auto' : '50px'};
+  height: 50px;
+  position: ${title => title.children === '...' && 'absolute'};
+`;

--- a/src/components/Option.js
+++ b/src/components/Option.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const OptionBox = ({ title, options }) => {
+  return (
+    <Options>
+      <OptionTitle>
+        {title}
+        <OptionLine />
+      </OptionTitle>
+      {options.map((option, idx) => (
+        <Option key={idx}>{option}</Option>
+      ))}
+    </Options>
+  );
+};
+
+export default OptionBox;
+
+const OptionTitle = styled.div`
+  position: relative;
+  margin-left: 30px;
+  padding: 10px 10px;
+  font-size: 13px;
+  color: #999;
+  background-color: #fff;
+`;
+const OptionLine = styled.span`
+  content: '';
+  display: block;
+  width: 100%;
+  height: 1px;
+  background: #ccc;
+  position: absolute;
+  top: -5px;
+  left: 0;
+  right: 0;
+`;
+
+const Options = styled.div`
+  padding-top: 20px;
+  font-size: ${props => props.theme.style.middleFont};
+  font-weight: 500;
+`;
+
+const Option = styled.div`
+  padding: 15px 20px;
+  font-size: 13px;
+  margin-left: 30px;
+`;

--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 const Nav = () => {
@@ -10,7 +11,9 @@ const Nav = () => {
           <SubLogo>코오롱이 답하다</SubLogo>
         </NavLeft>
         <NavRight>
-          <Li>+ 새설문 작성</Li>
+          <Li>
+            <Link to="/editor1">+ 새설문 작성</Link>
+          </Li>
           <Li>로그아웃</Li>
         </NavRight>
       </FlexContainer>

--- a/src/pages/editor/Editor.js
+++ b/src/pages/editor/Editor.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from 'styled-components';
+import OptionBox from '../../components/Option';
+import SurveyEditor from './SurveyEditor';
+
+const Editor = () => {
+  return (
+    <Container>
+      <SelectOption>
+        <OpitionContainer>
+          <OptionBox title="선택 질문 항목" options={SELECT_CATEGORY} />
+        </OpitionContainer>
+      </SelectOption>
+      <MakeSurvey>
+        <SurveyEditor />
+      </MakeSurvey>
+    </Container>
+  );
+};
+
+export default Editor;
+
+const Container = styled.div`
+  display: flex;
+  width: 100vw;
+  height: auto;
+  margin: 0 auto;
+  border: 1px solid grey;
+`;
+
+const SelectOption = styled.div`
+  flex: 1;
+  background-color: #fff;
+  border-right: 1px solid black;
+`;
+
+const MakeSurvey = styled.div`
+  flex: 2.5;
+`;
+
+const OpitionContainer = styled.div`
+  padding: 10px;
+`;
+
+const SELECT_CATEGORY = [
+  '객관식 단일 선택',
+  '객관식 복수 선택',
+  '주관식 짧은 답변 선택',
+  '주관식 긴 답변 선택',
+];

--- a/src/pages/editor/SurveyEditor.js
+++ b/src/pages/editor/SurveyEditor.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import GlobalButton from '../../components/GlobalButton';
+import styled from 'styled-components';
+
+const SurveyEditor = () => {
+  return (
+    <SurveyContainer>
+      <SurveyPage>
+        <TitleInput placeholder="제목 입력" />
+        <ActualQueryContainer>이곳을 클릭해서 추가하세요</ActualQueryContainer>
+        <NextContainer>
+          <GlobalButton title="이전으로 가기" />
+          <GlobalButton title="다음으로 가기" />
+        </NextContainer>
+      </SurveyPage>
+    </SurveyContainer>
+  );
+};
+
+export default SurveyEditor;
+
+const SurveyContainer = styled.div`
+  z-index: 1;
+  padding: 5px 10px;
+`;
+
+const SurveyPage = styled.div`
+  position: relative;
+  width: 770px;
+  margin: 99px auto 95px;
+  padding-top: 1px;
+  border-radius: 25px;
+  box-shadow: rgb(0 0 0 / 50%) 0px 0px 5px;
+  backdrop-filter: blur(30px);
+  background-color: rgb(255, 255, 255);
+`;
+
+const TitleInput = styled.input`
+  font-size: ${props => props.theme.style.middleFont};
+  font-family: 600;
+  padding: 15px 29px 8px;
+  margin-top: 15px;
+  margin-bottom: 22px;
+  text-align: left;
+  border: none;
+  border-radius: 25px;
+  outline: none;
+`;
+
+const ActualQueryContainer = styled.div`
+  padding: 18px 0 24px;
+  padding-bottom: 37px;
+  height: auto;
+  font-size: 16px;
+  line-height: 28px;
+  text-align: center;
+`;
+
+const NextContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  position: relative;
+  padding: 30px 49px 30px;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+`;


### PR DESCRIPTION

#### :: 구현 목표 
- 에디터 페이지 UI 구현 이전 Lay-out 구현을 목표로 함. 


#### :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. GlobalButton과 Option(선택항목 박)를 component에 빼서 필요한 곳에 import해서 사용.


<br />

#### :: 이슈 및 특이사항
1. 기본 Layout을 완성한 후, useForm을 사용하여 선택 항목을 눌렀을 때,  관리자가 사용할 선택 항목 양식이 생기게 할 것이고 다음을 누르면 관리자 설정항목을 설정할 수 있고 그 이후 완료를 누르면 어떤 타입의 질문들인지 그 안에 어떤 Content가 들어있었는지 객관식일 경우에는 몇개의 choice가 있었는지를 json 형태로 보내려고 함. 